### PR TITLE
Replaces backslashes from the template id for compatability

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function (opt) {
     }, opt);
     var data;
     try {
-      var template = twig({id: file.relative, data: file.contents.toString('utf8')});
+      var template = twig({id: file.relative.replace(/\\/g, '/'), data: file.contents.toString('utf8')});
       data = template.compile(options);
     } catch (err) {
       return cb(new PluginError('gulp-twig-compile', err));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-twig-compile",
   "description": "Compile Twig templates to javascript",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "homepage": "http://github.com/Naningans/gulp-twig-comoile",
   "repository": "git://github.com/Naningans/gulp-twig-comoile.git",

--- a/test.js
+++ b/test.js
@@ -97,6 +97,25 @@ describe('gulp-twig-compile', function() {
     Twig.twig.restore();
   });
 
+  it('should convert backslashes to forward slashes for the template id', function(done) {
+    var compile = twig_compile({module: 'amd'});
+
+    compile.on('data', function (file) {
+      file.relative.should.equal('views\\template.twig.js');
+
+      file.contents.toString('utf8').indexOf('id:"views/template.twig"').should.be.above(-1);
+
+      done();
+    });
+
+    var cwd = process.cwd().replace('/\/g', '\\');
+    compile.write(new gutil.File({
+      path: path.join(cwd, 'views\\template.twig').replace('/\/g', '\\'),
+      cwd: cwd,
+      contents: new Buffer('Twig template contents')
+    }));
+  });
+
   it('should emit errors correctly', function(done) {
     var template_stub = {};
     template_stub.compile = function(opt) { throw "FAIL!"};


### PR DESCRIPTION
The template ID is using file.relative, this breaks cygwin / windows due to back slashes
